### PR TITLE
update DOI for pyCIAM zenodo store

### DIFF
--- a/notebooks/data-acquisition.ipynb
+++ b/notebooks/data-acquisition.ipynb
@@ -51,7 +51,6 @@
     "from cartopy.io import shapereader\n",
     "from fsspec import FSTimeoutError\n",
     "from fsspec.implementations.zip import ZipFileSystem\n",
-    "from pyCIAM.utils import copy\n",
     "from shared import (\n",
     "    DIR_SHP,\n",
     "    DIR_SLR_AR5_IFILES_RAW,\n",
@@ -72,7 +71,9 @@
     "    PATH_SLR_HIST_TREND_MAP,\n",
     "    PATHS_SURGE_LOOKUP,\n",
     "    save,\n",
-    ")"
+    ")\n",
+    "\n",
+    "from pyCIAM.utils import copy"
    ]
   },
   {
@@ -93,7 +94,7 @@
     "# This will need to point to the correct version of the SLIIDERS zenodo store (see\n",
     "# Depsky et al. 2023 for the version associated with that manuscript)\n",
     "Z_SLIIDERS_DOI = \"7693868\"\n",
-    "Z_PYCIAM_DOI = \"7693869\"\n",
+    "Z_PYCIAM_DOI = \"8229860\"\n",
     "Z_AR6_DOI = \"6382554\"\n",
     "Z_SWEET_DOI = \"6067895\"\n",
     "\n",
@@ -119,7 +120,7 @@
     "\n",
     "# post-release\n",
     "PARAMS = {}\n",
-    "Z_URL = Z_URL_RECORDS"
+    "Z_URL_SLIIDERS_PC = Z_URL_RECORDS"
    ]
   },
   {
@@ -627,7 +628,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.10.8"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
Addresses #5 . Raw pyCIAM data has been updated in Zenodo to make the `subsets` variable bool rather than `int8`. This PR points the `data-acquisition.ipynb` notebook to the DOI of the updated Zenodo deposit, as well as fixes one variable name in that notebook