### PR TITLE
Better handle edges of surge lookup matrix

### DIFF
--- a/pyCIAM/io.py
+++ b/pyCIAM/io.py
@@ -310,14 +310,16 @@ def _load_lslr_for_ciam(
             .set_index(scen_mc=ix_names)
         )
 
-    # interpolate to yearly
+    # add on base year where slr is 0
     slr_out = slr_out.reindex(
         year=np.concatenate(([slr_0_year], slr.year.values)),
         fill_value=0,
     )
 
+    # interpolate to desired years
     if interp_years is not None:
         slr_out = slr_out.interp(year=interp_years)
+
     return slr_out
 
 

--- a/pyCIAM/run.py
+++ b/pyCIAM/run.py
@@ -1521,7 +1521,7 @@ def get_refA(
         [d for d in slr.dims if len(slr[d]) == 1 and d != "seg"], drop=True
     )
 
-    return calc_costs(
+    costs, refA = calc_costs(
         inputs, slr, surge_lookup=surge, return_year0_hts=True, **model_kwargs
     )
 

--- a/pyCIAM/run.py
+++ b/pyCIAM/run.py
@@ -401,7 +401,7 @@ def calc_costs(
                 surge_adapt = []
 
                 this_rh_diff_adapt = rh_diff.sel(seg=seg, drop=True)
-                _check_vals(this_rh_diff_noadapt, this_lslr, seg)
+                _check_vals(this_rh_diff_adapt, this_lslr, seg)
 
                 for adapttype in this_surge_lookup.adapttype.values:
                     this_surge_adapt = (

--- a/pyCIAM/run.py
+++ b/pyCIAM/run.py
@@ -341,14 +341,14 @@ def calc_costs(
                     "(initial adaptation) table if it was generated for a different "
                     "set of SLR scenarios or years."
                 )
+                # lslr is allowed to be below min surge lookup value b/c we created
+                # lookup such that < min value will be 0 impact
                 if rh_diff_arr.max() > this_surge_lookup.rh_diff.max():
                     raise ValueError(error_str.format("rh_diff", "higher", "maximum"))
                 if rh_diff_arr.min() < this_surge_lookup.rh_diff.min():
                     raise ValueError(error_str.format("rh_diff", "lower", "minimum"))
                 if lslr_arr.max() > this_surge_lookup.lslr.max():
                     raise ValueError(error_str.format("lslr", "higher", "maximum"))
-                if lslr_arr.min() < this_surge_lookup.lslr.min():
-                    raise ValueError(error_str.format("lslr", "lower", "minimum"))
 
             for seg in inputs.seg.values:
                 this_surge_lookup = (

--- a/pyCIAM/surge/lookup.py
+++ b/pyCIAM/surge/lookup.py
@@ -130,8 +130,8 @@ def _get_lslr_rhdiff_range(
         mins.append(min_lslr)
         maxs.append(max_lslr)
 
-    min_lslr = xr.concat(mins, dim="tmp").min("tmp")
-    max_lslr = xr.concat(maxs, dim="tmp").max("tmp")
+    min_lslr = xr.concat(mins, dim="tmp").min("tmp") - 2 * np.finfo("float32").eps
+    max_lslr = xr.concat(maxs, dim="tmp").max("tmp") + 2 * np.finfo("float32").eps
 
     at = _get_planning_period_map(lslr.year, at_start)
 

--- a/pyCIAM/utils.py
+++ b/pyCIAM/utils.py
@@ -94,8 +94,7 @@ def _get_lslr_plan_data(
     if diaz_negative_retreat:
         RH_heights = _pos(RH_heights)
     else:
-        for i in range(1, len(RH_heights.at)):
-            RH_heights[{"at": i}] = RH_heights.isel(at=slice(None, i + 1)).max("at")
+        RH_heights = RH_heights.cumulative("at").max()
 
     # set initial RH_heights to 0 (e.g.
     # assuming no retreat or protection anywhere such that both w/ and w/o climate


### PR DESCRIPTION
Not sure when it happened, but presumably due to some xarray updates, we now sometimes return missing values when pulling the surge impacts lookup for the no-climate-change scenario b/c we are at the lower bound of LSLR and sometimes due to some floating point issues are slightly below the lower bound. However, we do have real cases where interpolation targets are meaningfully below the lower bound of the matrix, in which case we want to assign 0s (which we are doing incorrectly at the moment). This PR updates the surge lookup creation to bump the lower and upper bounds of lslr by 2*epsilon so that we don't erroneously return 0s at the bounds of lslr lookup. It also improves our ability to catch other cases of unintentional surge lookup table interpolation targets falling outside the bounds of the table.

I also realized that the `dask.distributed.wait` function was not catching errored futures but instead was just releasing when all futures were *either* finished or errored. Not sure if this was always the case or a change in functionality of recent Dask versions, but now we use `client.gather` for futures that return None (so they are negligible in local memory impact) instead of `wait`

`get_refA` now also handles the potential edge case where it is run on a single segment, which previously would throw an error